### PR TITLE
Avoid warning regarding c style syntax

### DIFF
--- a/deimos/freeimage.di
+++ b/deimos/freeimage.di
@@ -198,7 +198,7 @@ alias PBITMAPINFOHEADER = BITMAPINFOHEADER*;
 
 struct BITMAPINFO {
   BITMAPINFOHEADER bmiHeader;
-  RGBQUAD          bmiColors[1];
+  RGBQUAD[1]       bmiColors;
 }
 alias PBITMAPINFO = BITMAPINFO*;
 


### PR DESCRIPTION
Saw warnings about the syntax as soon as I started to use a recent dmd compiler. This tweak avoided the warnings.
